### PR TITLE
Emergency fix for issue

### DIFF
--- a/backend/src/main/java/wordle_madness/backend/MainController.java
+++ b/backend/src/main/java/wordle_madness/backend/MainController.java
@@ -80,10 +80,13 @@ public class MainController {
 
     // Mechanism for logout and cached login
     @PatchMapping(path = "/logInOut")
-    public @ResponseBody String logInOut(@RequestParam String name, @RequestParam boolean newLoginState) {
+    public synchronized @ResponseBody String logInOut(@RequestParam String name, @RequestParam boolean newLoginState) {
         if (userRepository.existsUserByName(name)) {
             User currentUser = userRepository.findUserByName(name);
             if (newLoginState) {
+                if (currentUser.isLoggedIn()) {
+                    return "This user is already logged in. Please check that you have logged out of all other sessions";
+                }
                 currentUser.logIn();
             } else {
                 currentUser.logOut();


### PR DESCRIPTION
Fixed a bug where the user could concurrently login with 2 accounts, by logging in while on the confirmation prompt for cached login in another tab. Now, logging in another tab while this confirmation prompt is active will prevent the user from completing the cached login.